### PR TITLE
Update manifest examples to show origin scheme

### DIFF
--- a/explainer.md
+++ b/explainer.md
@@ -91,13 +91,13 @@ Example web app manifest at `https://contoso.com/manifest.json` :
     "capture_links": "existing_client_event",
     "url_handlers" : [
         {
-            "origin": "contoso.com"
+            "origin": "https://contoso.com"
         },
         {
-            "origin": "conto.so"
+            "origin": "https://conto.so"
         },
         {
-            "origin": "*.contoso.com"
+            "origin": "https://*.contoso.com"
         }
     ]
 }
@@ -119,13 +119,13 @@ Example web app manifest at `https://partnerapp.com/manifest.json`
     "capture_links": "existing_client_event",
     "url_handlers": [
         {
-            "origin": "contoso.com"
+            "origin": "https://contoso.com"
         },
         {
-            "origin": "conto.so"
+            "origin": "https://conto.so"
         },
         {
-            "origin": "*.contoso.com"
+            "origin": "https://*.contoso.com"
         }
     ]
 }


### PR DESCRIPTION
Currently the "https://" scheme is required by the `origin` fields in
`url_handlers`. This is consistent with Chromium's manifest parser
implementation. This change updates the manifest examples in this
explainer to reflect that. If there is feedback, we could consider
also allowing a short form of origin strings where the "https://" scheme
is implied.