### PR TITLE
Rename enum options

### DIFF
--- a/handle_links/explainer.md
+++ b/handle_links/explainer.md
@@ -45,7 +45,7 @@ We propose the addition of the `handle_links` member to the web app manifest tha
 
 * `preferred`: the user agent should open in-scope links within the installed application.
 * `not-preferred`: the user agent should not open links within the installed application.
-* `auto`: The user agent may select the appropriate behavior for the platform.
+* `auto`: The user agent should select the appropriate behavior for the platform.
 
 These options indicate an app's link handling preference. They should be seen as suggestions from an app to the user agent. 
 * `auto`: Default value if `handle_links` is not found in the manifest. The user agent may choose between `preferred` and `not-preferred`.

--- a/handle_links/explainer.md
+++ b/handle_links/explainer.md
@@ -47,7 +47,7 @@ We propose the addition of the `handle_links` member to the web app manifest tha
 * `not-preferred`: the use agent must not open links within the installed applications.
 * `auto`: The behavior is up to the user agent to decide what works best for the platform.
 
-The `mode` defines which links should be handled, where `auto` is the default and decided by the browser, `preferred` opens all link within scope in the installed web app and `not-preferred` allows for links to not be handled by the app.  
+The  options indicate the developer's link handling preference: `auto` is the default and allows the browser implementation to choose between `preferred` and `not-preferred`. `preferred` opens all link within scope in the installed web app and `not-preferred` allows for links to not be handled by the app.  
 
 ## Privacy and Security Considerations
 

--- a/handle_links/explainer.md
+++ b/handle_links/explainer.md
@@ -44,10 +44,13 @@ We propose the addition of the `handle_links` member to the web app manifest tha
 ```
 
 * `preferred`: the user agent should open in-scope links within the installed application.
-* `not-preferred`: the use agent must not open links within the installed applications.
-* `auto`: The behavior is up to the user agent to decide what works best for the platform.
+* `not-preferred`: the user agent should not open links within the installed application.
+* `auto`: The user agent may select the appropriate behavior for the platform.
 
-The  options indicate the developer's link handling preference: `auto` is the default and allows the browser implementation to choose between `preferred` and `not-preferred`. `preferred` opens all link within scope in the installed web app and `not-preferred` allows for links to not be handled by the app.  
+These options indicate an app's link handling preference. They should be seen as suggestions from an app to the user agent. 
+* `auto`: Default value if `handle_links` is not found in the manifest. The user agent may choose between `preferred` and `not-preferred`.
+* `preferred`: The user agent should handle links using matching app clients and may promote link handling behavior. 
+* `not-preferred`: The user agent should not handle links using matching app clients and may not promote link handling behavior.
 
 ## Privacy and Security Considerations
 

--- a/handle_links/explainer.md
+++ b/handle_links/explainer.md
@@ -40,17 +40,14 @@ In a similar vein, a user can click on a link of a music streaming service (www.
 We propose the addition of the `handle_links` member to the web app manifest that specifies the default link handling for the installed web app. The shape of this member is as follows:
 
 ```json
-"handle_links: {
-    "mode" : "auto" | "all" | "none"
-} "
+"handle_links: "auto" | "preferred" | "not-preferred"
 ```
 
-* `all`: the user agent should open in-scope links within the installed application.
-* `none`: the use agent must not open links within the installed applications.
+* `preferred`: the user agent should open in-scope links within the installed application.
+* `not-preferred`: the use agent must not open links within the installed applications.
 * `auto`: The behavior is up to the user agent to decide what works best for the platform.
 
-The `mode` defines which links should be handled, where `auto` is the default and decided by the browser, `all` opens all link within scope in the installed web app and `none` allows for links to not be handled by the app.  
-
+The `mode` defines which links should be handled, where `auto` is the default and decided by the browser, `preferred` opens all link within scope in the installed web app and `not-preferred` allows for links to not be handled by the app.  
 
 ## Privacy and Security Considerations
 


### PR DESCRIPTION
Rename enum options to auto | preferred | not-preferred. The new names are more suitable to represent the options as developer preferences that will be considered by the browser implementation.