### PR TITLE
Update status of Web App Link Handling Manifest Options

### DIFF
--- a/handle_links/explainer.md
+++ b/handle_links/explainer.md
@@ -4,7 +4,7 @@ Authors: [Diego Gonzalez](https://github.com/diekus), [Lu Huang](https://github.
 
 ## Status of this Document
 This document is a starting point for engaging the community and standards bodies in developing collaborative solutions fit for standardization. As the solutions to problems described in this document progress along the standards-track, we will retain this document as an archive and use this section to keep the community up-to-date with the most current standards venue and content location of future work and discussions.
-* This document status: **Active**
+* This document status: **Withdrawn**
 * Expected venue: [W3C Web Incubator Community Group](https://wicg.io/)
 * **Current version: this document**
     


### PR DESCRIPTION
Withdrawn according to https://bugs.chromium.org/p/chromium/issues/detail?id=1254457#c10.